### PR TITLE
Remove ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.6.4'
+# ruby '2.6.4'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '= 5.2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,8 +317,5 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
 
-RUBY VERSION
-   ruby 2.6.4p104
-
 BUNDLED WITH
    2.2.32


### PR DESCRIPTION
herokuにデプロイするために、gemのバージョン指定を削除